### PR TITLE
When setting default colour, also set selected colour.

### DIFF
--- a/colorpicker-library/src/main/java/petrov/kristiyan/colorpicker/ColorViewAdapter.java
+++ b/colorpicker-library/src/main/java/petrov/kristiyan/colorpicker/ColorViewAdapter.java
@@ -155,6 +155,7 @@ public class ColorViewAdapter extends RecyclerView.Adapter<ColorViewAdapter.View
                 colorPal.setCheck(true);
                 colorPosition = i;
                 notifyItemChanged(i);
+                colorSelected = color;
             }
         }
     }


### PR DESCRIPTION
Currently, if a user opens a dialog with a default colour, then that colour will be ticked, but when they click OK (without changing the color), the `color` passed into `OnChooseColorListener`'s `onChooseColor` function will be 0 (uninitialised int, as `colorSelected` is not initialised).